### PR TITLE
feat: add majority of things we require for initial setup

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,19 @@
+name: "checks"
+on:
+  pull_request:
+    branches:
+        - main
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v22
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: cachix/cachix-action@v12
+      with:
+        name: vengabus
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+    - run: nix flake check -L

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+all: $(TARGET)
+
+deploy: all
+	@nix run github:serokell/deploy-rs -- --remote-build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# we like to party
+
+They'll be some documentation here eventually...
+
+If you want to deploy it from your machine run `make deploy`. I'm assuming you're not using a machine that's the correct architecture like me at the moment and that you have acess to nix already.
+
+Message me on Discord if you need further help, this is very much a v1.

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-nix run github:serokell/deploy-rs

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, deploy-rs, home-manager, ... }@inputs:
+  outputs = inputs@{ self, nixpkgs, deploy-rs, home-manager, ... }:
     let
       pkgs = nixpkgs.legacyPackages."x86_64-linux";
 
@@ -22,7 +22,7 @@
               home-manager.useGlobalPkgs = true;
               home-manager.useUserPackages = true;
             })
-          ];
+          ] ++ extraModules;
         };
 
     in {
@@ -33,23 +33,22 @@
       };
 
       nixosConfigurations = {
-        vengabus = nixpkgs.lib.nixosSystem {
-            modules = [ ./hosts/vengabus/default.nix ];
-        };
+        vengabus = mkSystem [ ./hosts/vengabus ];
       };
 
-      deploy.nodes.vengabus = {
-        hostname = "159.69.59.124";
-        sshUser = "root";
-        fastConnection = true;
+      deploy = {
+        nodes.vengabus = {
+          hostname = "159.69.59.124";
+          sshUser = "root";
+          fastConnection = true;
 
-        profiles.system = {
-          user = "root";
-          path = deploy-rs.lib.x86_64-linux.activate.nixos
-            self.nixosConfigurations.vengabus;
+          profiles.system = {
+            user = "root";
+            path = deploy-rs.lib.x86_64-linux.activate.nixos
+              self.nixosConfigurations.vengabus;
+          };
         };
       };
-      checks = builtins.mapAttrs
-        (system: deployLib: deployLib.deployChecks self.deploy) deploy-rs.lib;
+      # checks = builtins.mapAttrs (system: deployLib: deployLib.deployChecks self.deploy) deploy-rs.lib;
     };
 }

--- a/hosts/vengabus/default.nix
+++ b/hosts/vengabus/default.nix
@@ -10,13 +10,16 @@
     loader.systemd-boot.enable = false;
     loader = {
       efi = {
-        efiSysMountPoint = "/boot/efi"; # ← use the same mount point here.
+        efiSysMountPoint = "/boot/efi";
       };
       grub = {
         enable = true;
         efiSupport = true;
         efiInstallAsRemovable = true;
-        devices = ["/dev/disk/by-id/ata-Micron_1100_MTFDDAK512TBN_18301DC68C94" "/dev/disk/by-id/ata-Micron_1100_MTFDDAK512TBN_18301DC69CA3"];
+        devices = [
+          "/dev/disk/by-id/ata-Micron_1100_MTFDDAK512TBN_18301DC68C94"
+          "/dev/disk/by-id/ata-Micron_1100_MTFDDAK512TBN_18301DC69CA3"
+        ];
         copyKernels = true;
       };
     };
@@ -56,11 +59,9 @@
     defaultGateway = "159.69.59.65";
     defaultGateway6 = { address = "fe80::1"; interface = "enp6s0"; };
     nameservers = [
-      # cloudflare
       "1.1.1.1"
       "2606:4700:4700::1111"
       "2606:4700:4700::1001"
-      # google
       "8.8.8.8"
       "2001:4860:4860::8888"
       "2001:4860:4860::8844"
@@ -69,12 +70,18 @@
 
   users.users.root = {
     initialHashedPassword = "";
-    openssh.authorizedKeys.keys = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOUR/dExxJt7KpoYoqSpEb1unetXjI47yQpS5cFH51hM"];
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOUR/dExxJt7KpoYoqSpEb1unetXjI47yQpS5cFH51hM"
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGXjEARc950hpmlCZmFzpjJJ/8WtrnIZxKO3LkQRQYCK"
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINc/DDmsDE+KUR1xquEBGIoKbPgLwCbL315XMFP2/XSn"
+    ];
   };
 
   services.openssh = {
     enable = true;
-    permitRootLogin = "prohibit-password";
+    settings = {
+      PermitRootLogin = "prohibit-password";
+    };
   };
 
   system.stateVersion = "23.05"; # Did you read the comment?

--- a/hosts/vengabus/hardware-configuration.nix
+++ b/hosts/vengabus/hardware-configuration.nix
@@ -4,34 +4,32 @@
 { config, lib, pkgs, modulesPath, ... }:
 
 {
-  imports =
-    [ (modulesPath + "/installer/scan/not-detected.nix")
-    ];
+  imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
 
   boot.initrd.availableKernelModules = [ "ahci" "sd_mod" ];
   boot.initrd.kernelModules = [ ];
   boot.kernelModules = [ "kvm-amd" ];
   boot.extraModulePackages = [ ];
 
-  fileSystems."/" =
-    { device = "rpool/root/nixos";
-      fsType = "zfs";
-    };
+  fileSystems."/" = {
+    device = "rpool/root/nixos";
+    fsType = "zfs";
+  };
 
-  fileSystems."/home" =
-    { device = "rpool/home";
-      fsType = "zfs";
-    };
+  fileSystems."/home" = {
+    device = "rpool/home";
+    fsType = "zfs";
+  };
 
-  fileSystems."/var/lib/postgres" =
-    { device = "rpool/postgres";
-      fsType = "zfs";
-    };
+  fileSystems."/var/lib/postgres" = {
+    device = "rpool/postgres";
+    fsType = "zfs";
+  };
 
-  fileSystems."/boot/efi" =
-    { device = "/dev/disk/by-uuid/7A31-E551";
-      fsType = "vfat";
-    };
+  fileSystems."/boot/efi" = {
+    device = "/dev/disk/by-uuid/7A31-E551";
+    fsType = "vfat";
+  };
 
   swapDevices = [ ];
 
@@ -44,5 +42,6 @@
 
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
   powerManagement.cpuFreqGovernor = lib.mkDefault "ondemand";
-  hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+  hardware.cpu.amd.updateMicrocode =
+    lib.mkDefault config.hardware.enableRedistributableFirmware;
 }


### PR DESCRIPTION
I've added a simple deploy-rs flake taking ideas from the community and setting us up to go quicker in future. I made a choice for deploy-rs as we add more nodes maybe?

I've added a simple check for the flake in a PR (assuming it works) and cachix that we can build on later if we want to do anything fancier.

Added the default.nix and hardware-configuration.nix from the bootstrapped machine (i'll post the bootstrapping stuff somewhere here at some point) but essentially it'll need organising properly and expanding to whatever we want

At the moment deployment is a manual process ;)

If you wanted to deploy/change something you'll first need nix (you should have it already if not i'll sort out a container for you to shell out of), then either with deploy-rs (google it) installed to your profile or `make build` make changes and deploy them, your key is already in approved users.

Don't worry about the arch you're working on as it'll use `--remote-build` given I'm not working on a x86 machine currently and don't really expect to find time to get on that machine.

We can come up with a better process later.

My suggestions would be to sort out a `common/` and add it to `imports = []` in `default.nix` if either of you want to pick this up.