### PR TITLE
Add Caddy

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
               home-manager.useUserPackages = true;
             })
             ./common
+            ./services
 
           ] ++ extraModules;
         };

--- a/hosts/vengabus/default.nix
+++ b/hosts/vengabus/default.nix
@@ -1,7 +1,7 @@
 { config, pkgs, ... }:
 
 {
-  imports = [ ./hardware-configuration.nix ];
+  imports = [./hardware-configuration.nix];
 
   boot = {
     loader.systemd-boot.enable = false;

--- a/services/caddy.nix
+++ b/services/caddy.nix
@@ -1,0 +1,36 @@
+{ config, pkgs, lib, modulesPath, ... }:
+
+let
+  caddyDir = "/var/lib/caddy";
+  mediumrareDomain = "mediumrare.ai";
+in
+{
+  services.caddy = {
+    enable = true;
+    email = "vengaboys-dev@example.com";
+    config = ''
+    {
+      storage file_system {
+        root ${caddyDir}
+      }
+    }
+    ${mediumrareDomain} {
+      reverse_proxy localhost:4000
+      encode gzip zstd
+      header / {
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "sameorigin"
+        Referrer-Policy "no-referrer-when-downgrade"
+        X-XSS-Protection "1; mode=block"
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+      }
+    }
+    www.${mediumrareDomain} {
+      redir https://${mediumrareDomain}{uri}
+    }
+    '';
+    adapter = "caddyfile";
+  };
+
+  networking.firewall.allowedTCPPorts = [ 80 443 ];
+}

--- a/services/default.nix
+++ b/services/default.nix
@@ -1,0 +1,5 @@
+{ config, lib, pkgs, ... }: {
+  imports = [ ./caddy.nix ];
+
+  # Put generalised common defaults across nodes in here
+}


### PR DESCRIPTION
As it stands, there's no way to expose or route traffic. 

This PR aims to add caddy to the vengaboys machine exposing port 80 and 443. 
From here we can use caddy to route traffic to our applications using it as a reverse proxy or serve files directly.

The idea behind this is that I will be deploying k3s in the future with traefik to replicate my production environment with a slight change to the traefik entry ports, to avoid blocking port 80 and 443 thus preventing any users from directing traffic to their applications outside of kubernetes. 
 
 I have added an initial structure for services to abstract services config and make it clearer for users the structure is:
 
 ```
 .
├── flake.nix
└── services
    ├── caddy.nix
    └── default.nix
```

Thank you for watching please like and subscribe for more broken builds 🚀 