### PR TITLE
Attempt to fix an error in caddy defaults and use virtualHosts 

### DIFF
--- a/services/caddy.nix
+++ b/services/caddy.nix
@@ -17,7 +17,7 @@
           }
         '';
     };
+  };
 
   networking.firewall.allowedTCPPorts = [ 80 443 ];
-  };
 }

--- a/services/caddy.nix
+++ b/services/caddy.nix
@@ -7,7 +7,7 @@
     virtualHosts."mediumrare.ai" = {
         extraConfig = ''
           reverse_proxy localhost:4000
-          encode gzip zstd
+          encode gzip
           header / {
             X-Content-Type-Options "nosniff"
             X-Frame-Options "sameorigin"

--- a/services/caddy.nix
+++ b/services/caddy.nix
@@ -1,36 +1,23 @@
 { config, pkgs, lib, modulesPath, ... }:
-
-let
-  caddyDir = "/var/lib/caddy";
-  mediumrareDomain = "mediumrare.ai";
-in
 {
   services.caddy = {
     enable = true;
     email = "vengaboys-dev@example.com";
-    config = ''
-    {
-      storage file_system {
-        root ${caddyDir}
-      }
-    }
-    ${mediumrareDomain} {
-      reverse_proxy localhost:4000
-      encode gzip zstd
-      header / {
-        X-Content-Type-Options "nosniff"
-        X-Frame-Options "sameorigin"
-        Referrer-Policy "no-referrer-when-downgrade"
-        X-XSS-Protection "1; mode=block"
-        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
-      }
-    }
-    www.${mediumrareDomain} {
-      redir https://${mediumrareDomain}{uri}
-    }
-    '';
-    adapter = "caddyfile";
-  };
+
+    virtualHosts."mediumrare.ai" = {
+        extraConfig = ''
+          reverse_proxy localhost:4000
+          encode gzip zstd
+          header / {
+            X-Content-Type-Options "nosniff"
+            X-Frame-Options "sameorigin"
+            Referrer-Policy "no-referrer-when-downgrade"
+            X-XSS-Protection "1; mode=block"
+            Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+          }
+        '';
+    };
 
   networking.firewall.allowedTCPPorts = [ 80 443 ];
+  };
 }


### PR DESCRIPTION
This Pr attempt to fix an error that occurred while applying the configuration on master 
`Error: adapting config using caddyfile: server block without any key is global configuration, and if used, it must be first`

I believe this is due to the defaults, therefore I am trying to use the config as per documentation to test if it works I have rewrote the caddy config to use the `virtualHosts`